### PR TITLE
Atomically write the json file

### DIFF
--- a/mdns.go
+++ b/mdns.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
@@ -21,7 +22,6 @@ import (
 	"hash/fnv"
 	"io/ioutil"
 	"log"
-	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -30,6 +30,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/hashicorp/mdns"
+	"github.com/natefinch/atomic"
 )
 
 type TargetGroup struct {
@@ -102,12 +103,10 @@ func main() {
 			if *output == "-" {
 				fmt.Println(string(y))
 			} else {
-				file, err := os.Create(*output) // For read access.
-				if err != nil {
+				buf := bytes.NewBuffer(y)
+				if err := atomic.WriteFile(*output, buf); err != nil {
 					log.Fatal(err)
 				}
-				file.Write(y)
-				file.Close()
 			}
 		}
 	}()


### PR DESCRIPTION
Hello,

I'm using your code and ended up with a lot of holes in the monitoring.
I also got many errors like this on Prometheus side (logs set to debug):
```
level=debug ts=2018-09-13T04:47:02.434227377Z caller=file.go:338 component="discovery manager scrape" discovery=file msg="file_sd refresh found file that should be removed" file=/opt/prometheus/etc/mdns-sd.json
level=error ts=2018-09-13T04:47:22.433789245Z caller=file.go:321 component="discovery manager scrape" discovery=file msg="Error reading file" path=/opt/prometheus/etc/mdns-sd.json err="unexpected end of JSON input"
level=debug ts=2018-09-13T04:47:22.434966794Z caller=file.go:338 component="discovery manager scrape" discovery=file msg="file_sd refresh found file that should be removed" file=/opt/prometheus/etc/mdns-sd.json
```

The issues seems that mdsn.go writes the file in a non atomic manner.
If prometheus reads the file when mdns.go writes it, the json may be truncated at the precise time prometheus reads it and fails to decode it.

Before:
 - truncate the file with `os.Create()`. The file is still here but empty
 - fill it
 - flush and close it

Here I just used a lib to atomically write the new json file:
 - write a new temporary file next to the old one
 - flush and close it
 - atomically rename it to replace the old one

System used (Raspberry Pi 3B):
prometheus-mdns compiled with:
 - go1.10.3
 - GOOS=linux
 - GOARCH=arm
 - GOARM=7

Prometheus used:
 - https://github.com/prometheus/prometheus/releases/download/v2.4.0/prometheus-2.4.0.linux-armv7.tar.gz